### PR TITLE
Replacing answers with example domain

### DIFF
--- a/app/routes/main.js
+++ b/app/routes/main.js
@@ -12,7 +12,7 @@ app.get('/', function(req, res, next) {
   }
 
   https.get({
-    host: 'answers.openmrs.org',
+    host: 'www.example.com',
     path: '/users/' + req.session.user.uid
   }, function(response) {
     if (response.statusCode === 200) {


### PR DESCRIPTION
answers.openmrs.org is now a redirect so we can't get a valid response on the necessary URL. In order for the site to be functional, we put this hack into production. This is a TEMPORARY fix and we need to get rid of this dependency, but this hack is necessary for production to work now that the site is shut down.